### PR TITLE
[CHAMADO-56760] Bump version number to 7.9.1 for Android and iOS

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -11,7 +11,6 @@
         </sparkle:tags>
       </item>
       <item>
-      <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>7.9.0</sparkle:version>
         <sparkle:tags>

--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -5,6 +5,14 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
+        <sparkle:version>7.9.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
+      </item>
+      <item>
+      <item>
+        <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>7.9.0</sparkle:version>
         <sparkle:tags>
           <sparkle:criticalUpdate />

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,13 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>7.9.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>7.9.0</sparkle:version>
         <sparkle:tags>
           <sparkle:criticalUpdate />


### PR DESCRIPTION
Update the changelog files for both Android and iOS to reflect the new version 7.9.1, indicating a critical update.