### PR TITLE
[AZUL-62839] Bump support update for Android and iOS

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -5,6 +5,13 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
+        <sparkle:version>8.0.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
+      </item>
+      <item>
+        <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>7.9.2</sparkle:version>
         <sparkle:tags>
           <sparkle:criticalUpdate />

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,13 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>8.0.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>7.9.2</sparkle:version>
         <sparkle:tags>
           <sparkle:criticalUpdate />


### PR DESCRIPTION
Add critical update entries for version 8.0.1 in both Android and iOS changelogs.