### PR TITLE
[CHAMADO-57934] Add version 8.2.1 to iOS changelog

### DIFF
--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,13 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>8.2.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>8.1.1</sparkle:version>
         <sparkle:tags>
           <sparkle:criticalUpdate />


### PR DESCRIPTION
Include the new version 8.2.1 in the iOS changelog with critical update tags.