### PR TITLE
[CHAMADO-58483] Add critical update tag for version 8.3.1 in changelogs

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -6,6 +6,9 @@
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>8.3.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>        
       </item>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -6,6 +6,9 @@
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>8.3.1</sparkle:version>
+        <sparkle:tags>
+          <sparkle:criticalUpdate />
+        </sparkle:tags>
       </item>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />


### PR DESCRIPTION
Introduce a critical update tag for version 8.3.1 in both Android and iOS changelogs to highlight the importance of this release.