### PR TITLE
[AZUL-75386] feat: add version 9.2.2 entries to Android and iOS changelogs

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
+        <sparkle:version>9.2.2</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>9.2.0</sparkle:version>
       </item>
       <item>

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>9.2.2</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>9.2.0</sparkle:version>
       </item>
       <item>


### PR DESCRIPTION
Include new entries for version 9.2.2 in the changelogs for both Android and iOS.
