### PR TITLE
[AZUL-93435] feat: recommended update 11.0.1 for Android and iOS

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
+        <sparkle:version>11.0.1</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>10.6.0</sparkle:version>
       </item>
       <item>

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>11.0.1</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>10.6.0</sparkle:version>
       </item>
       <item>


### PR DESCRIPTION
## Descrição

Adiciona a versão **11.0.1** como atualização **recomendada** para Android e iOS nos changelogs do app-cast.

Diferente de uma atualização crítica, o item é publicado sem a tag `<sparkle:criticalUpdate />`, portanto a atualização é sugerida ao usuário sem ser obrigatória.

## Alterações

- `app-cast/prd/android.xml` — novo item 11.0.1 no topo
- `app-cast/prd/ios.xml` — novo item 11.0.1 no topo

## Issue

AZUL-93435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 11.0.1 now available for Android and iOS applications, enabling users to access the latest updates through their respective platform stores and update channels
  * Updated application distribution feeds to reflect the new version availability and support automatic update detection across all supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->