### PR TITLE
[CHAMADO-67771] feat: optional update 11.0.6 for Android and iOS

### DIFF
--- a/app-cast/prd/android.xml
+++ b/app-cast/prd/android.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
+        <sparkle:version>11.0.6</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="android" url="market://details?id=com.contaazul.mobile.pro.ca_mobile_pro" />
         <sparkle:version>11.0.4</sparkle:version>
       </item>
       <item>

--- a/app-cast/prd/ios.xml
+++ b/app-cast/prd/ios.xml
@@ -5,6 +5,10 @@
     <language>en</language>
       <item>
         <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
+        <sparkle:version>11.0.6</sparkle:version>
+      </item>
+      <item>
+        <enclosure sparkle:os="ios" url="itms-apps://apps.apple.com/us/app/conta-azul-de-bolso/id1567614314" />
         <sparkle:version>11.0.4</sparkle:version>
       </item>
       <item>


### PR DESCRIPTION
## Descrição

Adiciona a versão **11.0.6** como atualização **opcional** para Android e iOS nos changelogs do app-cast.

Por ser uma atualização opcional, o item é publicado sem a tag `<sparkle:criticalUpdate />`, portanto a atualização é sugerida ao usuário sem ser obrigatória.

## Alterações

- `app-cast/prd/android.xml` — novo item 11.0.6 no topo
- `app-cast/prd/ios.xml` — novo item 11.0.6 no topo

## Issue

[CHAMADO-67771](https://contaazul.atlassian.net/browse/CHAMADO-67771) — Perfil Júnior com permissão para criar novos clientes no APP

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CHAMADO-67771]: https://contaazul.atlassian.net/browse/CHAMADO-67771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app update listings for Android and iOS to include the latest release version.
  * Added a new update entry so users can see and install version 11.0.6 from the app’s store listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->